### PR TITLE
Don't just use GCC-specific NTTP feature test

### DIFF
--- a/char8_t-remediation.h
+++ b/char8_t-remediation.h
@@ -15,7 +15,8 @@
 
 #if defined(__cpp_char8_t) // {
 
-#if defined(__cpp_nontype_template_parameter_class) \
+#if (defined(__cpp_nontype_template_parameter_class) \
+     || defined(__cpp_nontype_template_args)) \
  && defined(__cpp_deduction_guides) // {
 
 // Non-type template parameters with class type are supported.  This enables


### PR DESCRIPTION
__cpp_nontype_template_parameter_class is GCC-specific. It won't work in
Clang, for example. Also test for __cpp_nontype_template_args, which is
in the standard now. Keep the former test as well so that pre-standard
GCC versions still work.